### PR TITLE
Use Path::join instead of hardcoded forward slash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,13 +71,14 @@ impl Project {
 
         // parse Cargo.toml
         let toml = root.join("Cargo.toml");
+        let cargo_config = Path::new(".cargo").join("config");
         let manifest = parse::<Manifest>(&toml)?;
 
         // parse .cargo/config
         let mut target = None;
         let mut target_dir = env::var_os("CARGO_TARGET_DIR").map(PathBuf::from);
-        if let Some(path) = search(root, ".cargo/config") {
-            let config: Config = parse(&path.join(".cargo/config"))?;
+        if let Some(path) = search(root, &cargo_config) {
+            let config: Config = parse(&path.join(&cargo_config))?;
 
             if let Some(build) = config.build {
                 target = build.target;
@@ -259,8 +260,8 @@ impl Profile {
 }
 
 /// Search for `file` in `path` and its parent directories
-fn search<'p>(path: &'p Path, file: &str) -> Option<&'p Path> {
-    path.ancestors().find(|dir| dir.join(file).exists())
+fn search<'p, P: AsRef<Path>>(path: &'p Path, file: P) -> Option<&'p Path> {
+    path.ancestors().find(|dir| dir.join(&file).exists())
 }
 
 fn parse<T>(path: &Path) -> Result<T, failure::Error>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,51 +292,36 @@ mod tests {
             .path(Artifact::Bin("foo"), Profile::Dev, None, windows)
             .unwrap();
 
-        assert!(p.to_str().unwrap().ends_with("target/debug/foo.exe"));
+        assert!(p.ends_with("target/debug/foo.exe"));
 
         let p = project
             .path(Artifact::Example("bar"), Profile::Dev, None, windows)
             .unwrap();
 
-        assert!(p
-            .to_str()
-            .unwrap()
-            .ends_with("target/debug/examples/bar.exe"));
+        assert!(p.ends_with("target/debug/examples/bar.exe"));
 
         let p = project
             .path(Artifact::Bin("foo"), Profile::Dev, Some(thumb), windows)
             .unwrap();
 
-        assert!(p
-            .to_str()
-            .unwrap()
-            .ends_with(&format!("target/{}/debug/foo", thumb)));
+        assert!(p.ends_with(&format!("target/{}/debug/foo", thumb)));
 
         let p = project
             .path(Artifact::Example("bar"), Profile::Dev, Some(thumb), windows)
             .unwrap();
 
-        assert!(p
-            .to_str()
-            .unwrap()
-            .ends_with(&format!("target/{}/debug/examples/bar", thumb)));
+        assert!(p.ends_with(&format!("target/{}/debug/examples/bar", thumb)));
 
         let p = project
             .path(Artifact::Bin("foo"), Profile::Dev, Some(wasm), linux)
             .unwrap();
 
-        assert!(p
-            .to_str()
-            .unwrap()
-            .ends_with(&format!("target/{}/debug/foo.wasm", wasm)));
+        assert!(p.ends_with(&format!("target/{}/debug/foo.wasm", wasm)));
 
         let p = project
             .path(Artifact::Example("bar"), Profile::Dev, Some(wasm), linux)
             .unwrap();
 
-        assert!(p
-            .to_str()
-            .unwrap()
-            .ends_with(&format!("target/{}/debug/examples/bar.wasm", wasm)));
+        assert!(p.ends_with(&format!("target/{}/debug/examples/bar.wasm", wasm)));
     }
 }


### PR DESCRIPTION
For some reason Windows hates forward slashes which caused https://github.com/probe-rs/cargo-flash/issues/21. This should hopefully fix it.