### PR TITLE
Replace 'failure' dep with 'thiserror'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/japaric/cargo-project"
 version = "0.2.7"
 
 [dependencies]
-failure = "0.1.2"
+thiserror = "1"
 rustc-cfg = "0.4.0"
 serde = "1.0.79"
 serde_derive = "1.0.79"

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,8 @@ mod tests {
 [build]
 target = "thumbv7m-none-eabi"
 "#,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(config.build.unwrap().target.unwrap(), "thumbv7m-none-eabi")
     }
@@ -51,7 +52,8 @@ target = "thumbv7m-none-eabi"
 [target.thumbv7m-none-eabi]
 runner = "arm-none-eabi-gdb"
 "#,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert!(config.build.is_none());
     }
@@ -66,7 +68,8 @@ runner = "arm-none-eabi-gdb"
 [build]
 target = "thumbv7m-none-eabi"
 "#,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(config.build.unwrap().target.unwrap(), "thumbv7m-none-eabi");
     }
@@ -78,7 +81,8 @@ target = "thumbv7m-none-eabi"
 [build]
 target-dir = "custom-target"
 "#,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(config.build.unwrap().target_dir.unwrap(), "custom-target")
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -9,7 +9,7 @@ pub struct Manifest {
 pub struct Package {
     pub name: String,
     pub version: String,
-    pub description: Option<String>
+    pub description: Option<String>,
 }
 
 #[cfg(test)]
@@ -26,11 +26,11 @@ mod tests {
 name = "foo"
 version = "0.1"
 "#,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(manifest.package.name, "foo");
     }
-
 
     #[test]
     fn package_description_missing() {
@@ -40,7 +40,8 @@ version = "0.1"
 name = "foo"
 version = "0.1"
 "#,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(manifest.package.description, None);
     }
@@ -54,7 +55,8 @@ name = "foo"
 version = "0.1"
 description = "Test description"
 "#,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(manifest.package.description.unwrap(), "Test description");
     }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -23,7 +23,8 @@ mod tests {
 [workspace]
 members = ["foo", "bar"]
 "#,
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(manifest.workspace.members[0], "foo");
         assert_eq!(manifest.workspace.members[1], "bar");


### PR DESCRIPTION
The `failure` crate has been deprecated for some time, with a recommendation to use `thiserror` instead.  In addition, a critical memory safety issue (https://github.com/rust-lang-deprecated/failure/issues/336) has been found in `failure` that is unlikely to be fixed.  `rustc-cfg` is not vulnerable to the issue, but IMO it's better to just avoid having `failure` in our dependency trees at all.

This depends on `rustc-cfg` PR https://github.com/japaric/rustc-cfg/pull/15