### PR TITLE
replace Path::canonicalize with dunce::canonicalize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/japaric/cargo-project"
 version = "0.2.7"
 
 [dependencies]
+dunce = "1.0.4"
 glob = "0.3.0"
 log = "0.4.8"
 rustc-cfg = "0.5.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ impl Project {
     where
         P: AsRef<Path>,
     {
-        let path = path.as_ref().canonicalize()?;
+        let path = dunce::canonicalize(path)?;
         let root = search(&path, "Cargo.toml").ok_or(Error::NotACargoProject)?;
         debug!(
             "Project::query(path={}): root={}",


### PR DESCRIPTION
On Windows, upon canonicalization, the path may get [prefixed with `\\?`](https://github.com/rust-lang/rust/issues/42869). UNC paths cause issues when the lib tries to iterate over the workspace member globs, it looks like the `glob` crate doesn't like it very much.

Here is an example of this problem in the wild:
https://github.com/dfu-rs/cargo-dfu/issues/10