### PR TITLE
allow using workspace = true in Cargo.toml, fixes #16

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -5,16 +5,31 @@ pub struct Manifest {
     pub package: Package,
 }
 
+#[derive(Deserialize, Debug, PartialEq)]
+pub struct Workspace {
+    workspace: bool,
+}
+
+#[derive(Deserialize, Debug, PartialEq)]
+#[serde(untagged)]
+pub enum Version {
+    Str(String),
+    Map(Workspace),
+}
+
 #[derive(Deserialize)]
 pub struct Package {
     pub name: String,
-    pub version: String,
+    pub version: Version,
     pub description: Option<String>,
 }
 
 #[cfg(test)]
 mod tests {
     use toml;
+
+    use crate::manifest::Workspace;
+    use crate::manifest::Version;
 
     use super::Manifest;
 
@@ -59,5 +74,20 @@ description = "Test description"
         .unwrap();
 
         assert_eq!(manifest.package.description.unwrap(), "Test description");
+    }
+
+    #[test]
+    fn version_is_workspace() {
+        let manifest: Manifest = toml::from_str(
+            r#"
+[package]
+name = "foo"
+version = { workspace = true }
+description = "Test description"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(manifest.package.version, Version::Map(Workspace{workspace: true}));
     }
 }


### PR DESCRIPTION
This enables `cargo-project` to be used with workspaces, which may contain `version = { workspace = true }` in their `Cargo.toml`s